### PR TITLE
Include major SemVer updates in nightly CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: ./.github/actions/setup-node
 
       - name: Update astro and @astrojs/* dependencies
-        run: pnpm up -r "@astrojs/*" astro
+        run: pnpm up -r "@astrojs/*" astro --latest
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
I realised the action I added to auto-update our Astro dependencies doesn’t include major SemVer changes, so `@astrojs/db` got stuck on v0.8 (latest is 0.9).

This PR updates the action to add the `--latest` flag to the update command, so we can keep `@astrojs/db` as up-to-date as possible.